### PR TITLE
Add CLI documentation

### DIFF
--- a/cli/headless.adoc
+++ b/cli/headless.adoc
@@ -1,0 +1,31 @@
+[#cli-headless]
+=== Running on Headless Linux
+
+Please note that (at this time) `librepcb-cli` requires a running X-server
+even if it doesn't open any windows. If your system doesn't have an X-server
+running, you can use link:https://en.wikipedia.org/wiki/Xvfb[xvfb] instead:
+
+[source,bash]
+----
+$ xvfb-run -a librepcb-cli [args]
+----
+
+You may also need to install the OpenGL library (e.g. `libglu1-mesa`).
+
+[discrete]
+==== Running in Docker Container
+
+In addition to `xvfb`, running the LibrePCB CLI AppImage in a Docker
+container needs a workaround because FUSE is missing. See details here:
+https://github.com/AppImage/AppImageKit/wiki/FUSE#docker
+
+.Example Dockerfile
+[source,docker]
+----
+FROM ubuntu:18.04
+RUN apt-get update && apt-get -yy install wget ca-certificates libglu1-mesa qt5-default xvfb
+RUN wget https://download.librepcb.org/nightly_builds/master/librepcb-cli-nightly-linux-x86_64.AppImage
+RUN chmod a+x ./librepcb-cli-nightly-linux-x86_64.AppImage
+RUN ./librepcb-cli-nightly-linux-x86_64.AppImage --appimage-extract
+ENTRYPOINT ["sh", "-c", "xvfb-run -a ./squashfs-root/AppRun"]
+----

--- a/cli/index.adoc
+++ b/cli/index.adoc
@@ -1,0 +1,12 @@
+[#cli]
+== LibrePCB Command Line Interface
+:imagesdir: cli
+
+LibrePCB also provides a command line interface (CLI). With that tool, you
+can automate some tasks, for example on Continuous Integration (CI) systems.
+
+include::installation.adoc[]
+
+include::headless.adoc[]
+
+include::usage.adoc[]

--- a/cli/installation.adoc
+++ b/cli/installation.adoc
@@ -1,0 +1,45 @@
+[#cli-installation]
+=== Installation
+
+[discrete]
+==== Method 1: Installer
+
+If you have installed LibrePCB with the installer (as described 
+<<gettingstarted-installation,here>>), you should already have the `librepcb-cli`
+tool available in the installation directory.
+
+[discrete]
+==== Method 2: Portable Package
+
+Alternatively you could run `librepcb-cli` without installing it.
+
+[discrete]
+===== Windows
+:windows-zip-filename: librepcb-nightly-windows-x86.zip
+:windows-zip-url: https://download.librepcb.org/nightly_builds/master/librepcb-nightly-windows-x86.zip
+
+Download and extract {windows-zip-url}[{windows-zip-filename}], then
+run the contained file `bin\librepcb-cli.exe`.
+
+[discrete]
+===== Linux
+:linux-appimage-filename: librepcb-cli-nightly-linux-x86_64.AppImage
+:linux-appimage-url: https://download.librepcb.org/nightly_builds/master/librepcb-cli-nightly-linux-x86_64.AppImage
+
+Download {linux-appimage-url}[{linux-appimage-filename}], make it executable
+and start it:
+
+[source,bash,subs="attributes"]
+----
+wget "{linux-appimage-url}"
+chmod +x ./{linux-appimage-filename}
+./{linux-appimage-filename}
+----
+
+[discrete]
+===== Mac
+:dmg-filename: librepcb-cli-nightly-mac-x86_64.dmg
+:dmg-url: https://download.librepcb.org/nightly_builds/master/librepcb-cli-nightly-mac-x86_64.dmg
+
+Download {dmg-url}[{dmg-filename}] and double-click it. Then drag and drop the
+app onto the "Applications" icon of Finder.

--- a/cli/usage.adoc
+++ b/cli/usage.adoc
@@ -1,0 +1,111 @@
+[#cli-usage]
+=== Usage
+
+Usage instructions and available options can be shown with `--help`:
+
+.Command
+[source,bash]
+----
+$ ./librepcb-cli --help
+----
+
+.Output
+----
+Usage: ./librepcb-cli [options] command
+LibrePCB Command Line Interface
+
+Options:
+  -h, --help     Displays this help.
+  -v, --version  Displays version information.
+  --verbose      Verbose output.
+
+Arguments:
+  command        The command to execute.
+
+Commands:
+  open-project   Open a project to execute project-related tasks.
+----
+
+==== Command `open-project`
+
+This command opens a LibrePCB project and lets you execute some tasks with it.
+
+.Command
+[source,bash]
+----
+$ ./librepcb-cli open-project --help
+----
+
+.Output
+----
+Usage: ./librepcb-cli [options] open-project [command_options] project
+LibrePCB Command Line Interface
+
+Options:
+  -h, --help                      Displays this help.
+  -v, --version                   Displays version information.
+  --verbose                       Verbose output.
+  --check-erc                     Check ERC messages and add message count to
+                                  exit code (to report failure if there are
+                                  non-approved messages).
+  --export-schematics-pdf <file>  Export schematics as PDF to given file.
+                                  Existing file will be overwritten.
+  --export-gerber                 Export Gerber/Excellon files of boards
+                                  according their fabrication output settings.
+                                  Existing files will be overwritten.
+  --board <name>                  The name of the board(s) to export. Can be
+                                  given multiple times. If not set, all boards
+                                  are exported.
+  --save                          Save project before closing it (useful to
+                                  upgrade file format).
+
+Arguments:
+  open-project                    Open a project to execute project-related
+                                  tasks.
+  project                         Path to project file (*.lpp).
+----
+
+[discrete]
+===== Example: Check ERC Messages and Export Schematics & Boards
+
+This command is useful for Continuous Integration of LibrePCB projects because
+it reports failure if you check in projects with non-approved ERC messages. In
+addition, it generates all production data so you don't have to do it manually.
+
+.Command
+[source,bash]
+----
+$ ./librepcb-cli open-project \
+    --check-erc \
+    --export-gerber \
+    --export-schematics-pdf="output/schematics.pdf" \
+    MyProject.lpp
+----
+
+.Output
+----
+Open project 'MyProject.lpp'...
+  Done.
+Check ERC messages...
+  Approved: 7
+  Non-approved: 2
+    - [WARNING] Net signal connected to less than two pins: "CAN_RX"
+    - [WARNING] Net signal connected to less than two pins: "JTCK"
+Export schematics as PDF to 'output/schematics.pdf'...
+  Done.
+Export Gerber/Excellon files...
+  Board 'default':
+    => 'output/v1/gerber/MyProject_DRILLS-PTH.drl'
+    => 'output/v1/gerber/MyProject_OUTLINES.gbr'
+    => 'output/v1/gerber/MyProject_COPPER-TOP.gbr'
+    => 'output/v1/gerber/MyProject_COPPER-BOTTOM.gbr'
+    => 'output/v1/gerber/MyProject_SOLDERMASK-TOP.gbr'
+    => 'output/v1/gerber/MyProject_SOLDERMASK-BOTTOM.gbr'
+    => 'output/v1/gerber/MyProject_SILKSCREEN-TOP.gbr'
+    => 'output/v1/gerber/MyProject_SILKSCREEN-BOTTOM.gbr'
+  Done.
+Finished with errors!
+----
+
+In this example, the application reported an error and exited with code 2
+because there are two non-approved ERC messages.

--- a/cli/usage.adoc
+++ b/cli/usage.adoc
@@ -42,27 +42,29 @@ Usage: ./librepcb-cli [options] open-project [command_options] project
 LibrePCB Command Line Interface
 
 Options:
-  -h, --help                      Displays this help.
-  -v, --version                   Displays version information.
-  --verbose                       Verbose output.
-  --check-erc                     Check ERC messages and add message count to
-                                  exit code (to report failure if there are
-                                  non-approved messages).
-  --export-schematics-pdf <file>  Export schematics as PDF to given file.
-                                  Existing file will be overwritten.
-  --export-gerber                 Export Gerber/Excellon files of boards
-                                  according their fabrication output settings.
-                                  Existing files will be overwritten.
-  --board <name>                  The name of the board(s) to export. Can be
-                                  given multiple times. If not set, all boards
-                                  are exported.
-  --save                          Save project before closing it (useful to
-                                  upgrade file format).
+  -h, --help                     Displays this help.
+  -v, --version                  Displays version information.
+  --verbose                      Verbose output.
+  --erc                          Run the electrical rule check, print all
+                                 non-approved warnings/errors and report failure
+                                 (exit code = 1) if there are non-approved
+                                 messages.
+  --export-schematics <file>     Export schematics to given file(s). Existing
+                                 files will be overwritten. Supported file
+                                 extensions: pdf
+  --export-pcb-fabrication-data  Export PCB fabrication data (Gerber/Excellon)
+                                 according the fabrication output settings of
+                                 boards. Existing files will be overwritten.
+  --board <name>                 The name of the board(s) to export. Can be
+                                 given multiple times. If not set, all boards
+                                 are exported.
+  --save                         Save project before closing it (useful to
+                                 upgrade file format).
 
 Arguments:
-  open-project                    Open a project to execute project-related
-                                  tasks.
-  project                         Path to project file (*.lpp).
+  open-project                   Open a project to execute project-related
+                                 tasks.
+  project                        Path to project file (*.lpp).
 ----
 
 [discrete]
@@ -76,24 +78,23 @@ addition, it generates all production data so you don't have to do it manually.
 [source,bash]
 ----
 $ ./librepcb-cli open-project \
-    --check-erc \
-    --export-gerber \
-    --export-schematics-pdf="output/schematics.pdf" \
+    --erc \
+    --export-schematics="output/{{VERSION}}/{{PROJECT}}_Schematics.pdf" \
+    --export-pcb-fabrication-data \
     MyProject.lpp
 ----
 
 .Output
 ----
 Open project 'MyProject.lpp'...
-  Done.
-Check ERC messages...
-  Approved: 7
-  Non-approved: 2
+Run ERC...
+  Approved messages: 7
+  Non-approved messages: 2
     - [WARNING] Net signal connected to less than two pins: "CAN_RX"
     - [WARNING] Net signal connected to less than two pins: "JTCK"
-Export schematics as PDF to 'output/schematics.pdf'...
-  Done.
-Export Gerber/Excellon files...
+Export schematics to 'output/{{VERSION}}/{{PROJECT}}_Schematics.pdf'...
+  => 'output/v1/MyProject_Schematics.pdf'
+Export PCB fabrication data...
   Board 'default':
     => 'output/v1/gerber/MyProject_DRILLS-PTH.drl'
     => 'output/v1/gerber/MyProject_OUTLINES.gbr'
@@ -103,9 +104,8 @@ Export Gerber/Excellon files...
     => 'output/v1/gerber/MyProject_SOLDERMASK-BOTTOM.gbr'
     => 'output/v1/gerber/MyProject_SILKSCREEN-TOP.gbr'
     => 'output/v1/gerber/MyProject_SILKSCREEN-BOTTOM.gbr'
-  Done.
 Finished with errors!
 ----
 
-In this example, the application reported an error and exited with code 2
-because there are two non-approved ERC messages.
+In this example, the application reported errors and exited with code 1
+because there are non-approved ERC messages.

--- a/index.adoc
+++ b/index.adoc
@@ -11,4 +11,5 @@
 
 include::about/index.adoc[]
 include::getting_started/index.adoc[]
+include::cli/index.adoc[]
 include::api/index.adoc[]


### PR DESCRIPTION
Documentation for https://github.com/LibrePCB/LibrePCB/pull/299.

Rendered: https://docs.librepcb.org/_branches/add-cli/#cli