### PR TITLE
Add minimal silkscreen-copper clearance

### DIFF
--- a/library_conventions/packages.adoc
+++ b/library_conventions/packages.adoc
@@ -212,7 +212,8 @@ most important rules are the following:
   placement layer should primarily contain drawings _around_ the package's
   body, but not _under_ it.
 * *Line width:* 0.15mm typical, 0.1mm minimum
-* *Clearance to copper layers:* Equal or greater than the line width
+* *Clearance to copper layers:* Equal or greater than the line width, but at
+  least 0.15mm
 
 .Placement layer examples (only placement and copper layers shown)
 ====


### PR DESCRIPTION
This matches the warnings in the library editor.