### PR TITLE
Extend CLI installation instructions for Linux

### DIFF
--- a/cli/headless.adoc
+++ b/cli/headless.adoc
@@ -10,22 +10,11 @@ running, you can use link:https://en.wikipedia.org/wiki/Xvfb[xvfb] instead:
 $ xvfb-run -a librepcb-cli [args]
 ----
 
-You may also need to install the OpenGL library (e.g. `libglu1-mesa`).
 
-[discrete]
-== Running in Docker Container
+If the `librepcb-cli` executable still dosn't work, you may need to install
+some dependencies. On Debian/Ubuntu, following packages need to be installed:
 
-In addition to `xvfb`, running the LibrePCB CLI AppImage in a Docker
-container needs a workaround because FUSE is missing. See details here:
-https://github.com/AppImage/AppImageKit/wiki/FUSE#docker
-
-.Example Dockerfile
-[source,docker,subs="attributes"]
+[source,bash]
 ----
-FROM ubuntu:18.04
-RUN apt-get update && apt-get -yy install wget ca-certificates libglu1-mesa qt5-default xvfb
-RUN wget "{releases_url}/librepcb-cli-{version}-linux-x86_64.AppImage"
-RUN chmod a+x ./librepcb-cli-{version}-linux-x86_64.AppImage
-RUN ./librepcb-cli-{version}-linux-x86_64.AppImage --appimage-extract
-ENTRYPOINT ["sh", "-c", "xvfb-run -a ./squashfs-root/AppRun"]
+$ apt-get install libfontconfig1 libglib2.0-0 libglu1-mesa
 ----

--- a/cli/installation.adoc
+++ b/cli/installation.adoc
@@ -25,6 +25,15 @@ run the contained file `bin\librepcb-cli.exe`.
 === Linux
 :linux-appimage-filename: librepcb-cli-{version}-linux-x86_64.AppImage
 :linux-appimage-url: {releases_url}/{linux-appimage-filename}
+:linux-targz-foldername: librepcb-{version}-linux-x86_64
+:linux-targz-filename: librepcb-{version}-linux-x86_64.tar.gz
+:linux-targz-url: {releases_url}/{linux-targz-filename}
+:linux-docker-name: librepcb/librepcb-cli
+:linux-docker-tag: {linux-docker-name}:{version}
+:linux-docker-url: https://hub.docker.com/r/{linux-docker-name}
+
+[discrete]
+==== AppImage
 
 Download {linux-appimage-url}[{linux-appimage-filename}], make it executable
 and start it:
@@ -34,6 +43,31 @@ and start it:
 wget "{linux-appimage-url}"
 chmod +x ./{linux-appimage-filename}
 ./{linux-appimage-filename}
+----
+
+[discrete]
+==== Binaries
+
+Alternatively, you can download and extract
+{linux-targz-url}[{linux-targz-filename}] which contains the `librepcb-cli`
+executable:
+
+[source,bash,subs="attributes"]
+----
+wget "{linux-targz-url}"
+tar -xvzf ./{linux-targz-filename}
+./{linux-targz-foldername}/bin/librepcb-cli
+----
+
+[discrete]
+==== Docker
+
+Or if you have https://www.docker.com/[Docker] installed, you can use our
+official image {linux-docker-url}[`{linux-docker-name}`]:
+
+[source,bash,subs="attributes"]
+----
+docker run -it --rm -u $(id -u):$(id -g) -v `pwd`:/work {linux-docker-tag}
 ----
 
 [discrete]


### PR DESCRIPTION
Mention the new *.tar.gz archive with binaries, and the librepcb-cli Docker image.