### PR TITLE
Different tool recommendations for OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ On Linux the required tools can be installed with following commands:
     gem install asciidoctor pygments.rb rouge
     gem install asciidoctor-pdf --pre
 
+On Mac you can use [homebrew](https://brew.sh/) and install gems in your user
+folder:
+
+    brew install asciidoctor
+    gem install --user-install pygments.rb rouge
+
+This will keep your installation more resilient to OS X upgrades.
+
 ## Building
 
     asciidoctor index.adoc          # build index.html


### PR DESCRIPTION
Installed gems in OSX usually goes to a folder inside /Library, which
may get deleted and recreated after upgrading the operating system.

This changes proposes OSX users to use of homebrew and home folder
install, which will be more resilient to upgrades. Also, depending on
how homebrew was installed, this will also not require super-user
privileges.