### PR TITLE
Fix link to GitHub documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,4 +78,4 @@ and rendered output), please follow these rules:
 ## Additional Resources
 
 - [General GitHub documentation](https://help.github.com/)
-- [GitHub pull request documentation](https://help.github.com/send-pull-requests/)
+- [GitHub pull request documentation](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests)


### PR DESCRIPTION
The CONTRIBUTING.md contained an old link to GitHub help which now fails
with a 404 page. This changes the link to an address that seems to be
equivalent.