### PR TITLE
Collapsable menus

### DIFF
--- a/docinfo-footer.html
+++ b/docinfo-footer.html
@@ -1,3 +1,49 @@
 <div id="footer-github">
     Edit these docs <a href="https://github.com/LibrePCB/librepcb-doc/">on GitHub</a>!
 </div>
+<script type="text/javascript">
+  function tocLinkCloseAll() {
+    Array.from(document.querySelectorAll(".toc-visible")).forEach(function(item) {
+      item.classList.remove("toc-visible");
+      item.classList.add("toc-invisible");
+    });
+  }
+  function tocLinkOpen(ul) {
+    ul.classList.remove("toc-invisible");
+    ul.classList.add("toc-visible");
+  }
+  function tocLinkOpenAncestors(ul) {
+    var ancestor = ul.parentNode.closest("ul");
+    if (ancestor) {
+      tocLinkOpen(ancestor);
+      tocLinkOpenAncestors(ancestor);
+    }
+  }
+  function tocLinkOpenSibling(self) {
+    var sib = self.parentNode.querySelector("ul");
+    if (sib) tocLinkOpen(sib);
+  }
+  function tocLinkOpenAt(self) {
+    tocLinkOpenSibling(self);
+    tocLinkOpenAncestors(self);
+  }
+  function tocLinkToggle() {
+    tocLinkCloseAll();
+    tocLinkOpenAt(this);
+  }
+  (function() {
+    Array.from(document.querySelectorAll("#toc ul > li > ul")).forEach(function(a) {
+      a.classList.add("toc-invisible");
+    });
+    Array.from(document.querySelectorAll("#toc ul > li > a")).forEach(function(a) {
+      a.onclick = tocLinkToggle;
+    });
+    var hash = document.location.hash;
+    if (hash) {
+      var hash_a = document.querySelector("a[href='" + hash + "']");
+      if (hash_a) {
+        tocLinkOpenAt(hash_a);
+      }
+    }
+  })();
+</script>

--- a/docinfo-footer.html
+++ b/docinfo-footer.html
@@ -2,47 +2,51 @@
     Edit these docs <a href="https://github.com/LibrePCB/librepcb-doc/">on GitHub</a>!
 </div>
 <script type="text/javascript">
+  const tocVisibleCssClass = "toc-visible";
+  const tocHiddenCssClass = "toc-invisible";
+
   function tocLinkCloseAll() {
-    Array.from(document.querySelectorAll(".toc-visible")).forEach(function(item) {
-      item.classList.remove("toc-visible");
-      item.classList.add("toc-invisible");
-    });
+    for (const item of document.querySelectorAll(".toc-visible")) {
+      item.classList.remove(tocVisibleCssClass);
+      item.classList.add(tocHiddenCssClass);
+    }
   }
   function tocLinkOpen(ul) {
-    ul.classList.remove("toc-invisible");
-    ul.classList.add("toc-visible");
+    ul.classList.remove(tocHiddenCssClass);
+    ul.classList.add(tocVisibleCssClass);
   }
   function tocLinkOpenAncestors(ul) {
-    var ancestor = ul.parentNode.closest("ul");
+    const ancestor = ul.parentNode.closest("ul");
     if (ancestor) {
       tocLinkOpen(ancestor);
       tocLinkOpenAncestors(ancestor);
     }
   }
   function tocLinkOpenSibling(self) {
-    var sib = self.parentNode.querySelector("ul");
+    const sib = self.parentNode.querySelector("ul");
     if (sib) tocLinkOpen(sib);
   }
   function tocLinkOpenAt(self) {
     tocLinkOpenSibling(self);
     tocLinkOpenAncestors(self);
   }
-  function tocLinkToggle() {
+  function tocLinkToggle(event) {
     tocLinkCloseAll();
-    tocLinkOpenAt(this);
+    tocLinkOpenAt(event.target);
   }
   (function() {
-    Array.from(document.querySelectorAll("#toc ul > li > ul")).forEach(function(a) {
-      a.classList.add("toc-invisible");
-    });
-    Array.from(document.querySelectorAll("#toc ul > li > a")).forEach(function(a) {
+    for (const ul of document.querySelectorAll("#toc ul > li > ul")) {
+      ul.classList.add(tocHiddenCssClass);
+    }
+    for (const a of document.querySelectorAll("#toc ul > li > a")) {
       a.onclick = tocLinkToggle;
-    });
-    var hash = document.location.hash;
+    }
+
+    const hash = document.location.hash;
     if (hash) {
-      var hash_a = document.querySelector("a[href='" + hash + "']");
-      if (hash_a) {
-        tocLinkOpenAt(hash_a);
+      const hashA = document.querySelector(`a[href='${hash}']`);
+      if (hashA) {
+        tocLinkOpenAt(hashA);
       }
     }
   })();

--- a/style.css
+++ b/style.css
@@ -441,3 +441,10 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 #footer-github a {
     color: #89aee5;
 }
+
+#toc .toc-invisible {
+    display: none;
+}
+#toc .toc-visible {
+    display: block;
+}


### PR DESCRIPTION
This introduces a small Javascript snipped at the bottom of the generated output. This JS block will hide all sections after the page loads and show the current visible anchor.

The script will also inject a click listener to keep only the currently visited item open. Since the output is a single HTML file, this trick won't be a nuisance.

This is transparent for readers without Javascript enabled. They are presumably rare, but we never know. Those users will have to deal with a long TOC.

Notes:
* In retrospective, I could do the same in JS-only. But having explicit CSS classes seems better to maintain.
* I also tried to inject this solution in Asciidoctor own docs (since their TOC is much longer than ours) and results look great.
* When comparing this to other solutions to issue #20 at least this one provides some immediate value without deeply changing the way we write our docs.