### PR TITLE
Add documentation about licenses

### DIFF
--- a/modules/user-manual/nav.adoc
+++ b/modules/user-manual/nav.adoc
@@ -1,5 +1,6 @@
 * xref:index.adoc[]
 ** xref:layers.adoc[]
+** xref:licenses.adoc[]
 ** Project Editor
 *** xref:project-editor/assembly-data.adoc[]
 *** xref:project-editor/output-jobs.adoc[]

--- a/modules/user-manual/pages/licenses.adoc
+++ b/modules/user-manual/pages/licenses.adoc
@@ -30,7 +30,8 @@ version):
 |===
 | License | Permissions | Conditions | Limitations
 
-| *https://creativecommons.org/publicdomain/zero/1.0/[CC0-1.0]* +
+|{set:cellbgcolor:#00FF0020}
+*https://creativecommons.org/publicdomain/zero/1.0/[CC0-1.0]* +
 https://choosealicense.com/licenses/cc0-1.0/[Summary]
 |
 ✅ Distribution +
@@ -41,7 +42,8 @@ https://choosealicense.com/licenses/cc0-1.0/[Summary]
 ❌ No liability +
 ❌ No warranty +
 
-| *https://creativecommons.org/licenses/by/4.0/[CC-BY-4.0]* +
+|{set:cellbgcolor:-}
+*https://creativecommons.org/licenses/by/4.0/[CC-BY-4.0]* +
 https://choosealicense.com/licenses/cc-by-4.0/[Summary]
 |
 ✅ Distribution +
@@ -96,7 +98,7 @@ https://choosealicense.com/licenses/cc-by-sa-4.0/[Summary]
 | *https://creativecommons.org/licenses/by-nc-nd/4.0/[CC-BY-NC-ND-4.0]*
 |
 ✅ Distribution +
-✅ Modification +
+✅ (Modification) +
 |
 ⚠ <<license-notice>> +
 ⚠ <<license-statechanges>> +
@@ -109,7 +111,7 @@ https://choosealicense.com/licenses/cc-by-sa-4.0/[Summary]
 | *https://creativecommons.org/licenses/by-nd/4.0/[CC-BY-ND-4.0]*
 |
 ✅ Distribution +
-✅ Modification +
+✅ (Modification) +
 ✅ Commercial use +
 |
 ⚠ <<license-notice>> +

--- a/modules/user-manual/pages/licenses.adoc
+++ b/modules/user-manual/pages/licenses.adoc
@@ -30,7 +30,8 @@ version):
 |===
 | License | Permissions | Conditions | Limitations
 
-| https://creativecommons.org/publicdomain/zero/1.0/[CC0-1.0]
+| *https://creativecommons.org/publicdomain/zero/1.0/[CC0-1.0]* +
+https://choosealicense.com/licenses/cc0-1.0/[Summary]
 |
 ✅ Distribution +
 ✅ Modification +
@@ -40,7 +41,8 @@ version):
 ❌ No liability +
 ❌ No warranty +
 
-| https://creativecommons.org/licenses/by/4.0/[CC-BY-4.0]
+| *https://creativecommons.org/licenses/by/4.0/[CC-BY-4.0]* +
+https://choosealicense.com/licenses/cc-by-4.0/[Summary]
 |
 ✅ Distribution +
 ✅ Modification +
@@ -51,7 +53,8 @@ version):
 ❌ No liability +
 ❌ No warranty +
 
-| https://creativecommons.org/licenses/by-sa/4.0/[CC-BY-SA-4.0]
+| *https://creativecommons.org/licenses/by-sa/4.0/[CC-BY-SA-4.0]* +
+https://choosealicense.com/licenses/cc-by-sa-4.0/[Summary]
 |
 ✅ Distribution +
 ✅ Modification +
@@ -63,7 +66,7 @@ version):
 ❌ No liability +
 ❌ No warranty +
 
-| https://creativecommons.org/licenses/by-nc/4.0/[CC-BY-NC-4.0]
+| *https://creativecommons.org/licenses/by-nc/4.0/[CC-BY-NC-4.0]*
 |
 ✅ Distribution +
 ✅ Modification +
@@ -74,7 +77,7 @@ version):
 ❌ No warranty +
 ❌ Non-commercial only +
 
-| https://creativecommons.org/licenses/by-nc-sa/4.0/[CC-BY-NC-SA-4.0]
+| *https://creativecommons.org/licenses/by-nc-sa/4.0/[CC-BY-NC-SA-4.0]*
 |
 ✅ Distribution +
 ✅ Modification +
@@ -86,7 +89,7 @@ version):
 ❌ No warranty +
 ❌ Non-commercial only +
 
-| https://creativecommons.org/licenses/by-nc-nd/4.0/[CC-BY-NC-ND-4.0]
+| *https://creativecommons.org/licenses/by-nc-nd/4.0/[CC-BY-NC-ND-4.0]*
 |
 ✅ Distribution +
 ✅ Modification +
@@ -98,7 +101,7 @@ version):
 ❌ No derivatives +
 ❌ Non-commercial only +
 
-| https://creativecommons.org/licenses/by-nd/4.0/[CC-BY-ND-4.0]
+| *https://creativecommons.org/licenses/by-nd/4.0/[CC-BY-ND-4.0]*
 |
 ✅ Distribution +
 ✅ Modification +
@@ -110,30 +113,64 @@ version):
 ❌ No warranty +
 ❌ No derivatives +
 
-| https://tapr.org/the-tapr-open-hardware-license/[TAPR-OHL-1.0]
+| *https://tapr.org/the-tapr-open-hardware-license/[TAPR-OHL-1.0]*
 |
 ✅ Distribution +
 ✅ Modification +
 ✅ Commercial use +
 |
 ⚠ <<license-sharealike>> +
-⚠ Document modifications +
+⚠ <<license-documentmodifications>> +
 ⚠ Notify upstream developers +
 |
 ❌ No liability +
 ❌ No warranty +
 
-| https://ohwr.org/cern_ohl_p_v2.pdf[CERN-OHL-P-2.0]
-(https://ohwr.org/project/cernohl/wikis/faq[FAQ])
-3+^| _TBD_
+| *https://ohwr.org/cern_ohl_p_v2.pdf[CERN-OHL-P-2.0]* +
+https://choosealicense.com/licenses/cern-ohl-p-2.0/[Summary] +
+https://ohwr.org/project/cernohl/wikis/faq[FAQ]
+|
+✅ Distribution +
+✅ Modification +
+✅ Commercial use +
+|
+⚠ <<license-documentmodifications>> +
+⚠ License and copyright notice +
+|
+❌ No liability +
+❌ No warranty +
 
-| https://ohwr.org/cern_ohl_w_v2.pdf[CERN-OHL-W-2.0]
-(https://ohwr.org/project/cernohl/wikis/faq[FAQ])
-3+^| _TBD_
+| *https://ohwr.org/cern_ohl_w_v2.pdf[CERN-OHL-W-2.0]* +
+https://choosealicense.com/licenses/cern-ohl-w-2.0/[Summary] +
+https://ohwr.org/project/cernohl/wikis/faq[FAQ]
+|
+✅ Distribution +
+✅ Modification +
+✅ Commercial use +
+|
+⚠ <<license-sharealike>> (relaxed) +
+⚠ <<license-documentmodifications>> +
+⚠ License and copyright notice +
+⚠ Disclose source +
+|
+❌ No liability +
+❌ No warranty +
 
-| https://ohwr.org/cern_ohl_s_v2.pdf[CERN-OHL-S-2.0]
-(https://ohwr.org/project/cernohl/wikis/faq[FAQ])
-3+^| _TBD_
+| *https://ohwr.org/cern_ohl_s_v2.pdf[CERN-OHL-S-2.0]* +
+https://choosealicense.com/licenses/cern-ohl-s-2.0/[Summary] +
+https://ohwr.org/project/cernohl/wikis/faq[FAQ]
+|
+✅ Distribution +
+✅ Modification +
+✅ Commercial use +
+|
+⚠ <<license-sharealike>> (strong) +
+⚠ <<license-documentmodifications>> +
+⚠ License and copyright notice +
+⚠ Disclose source +
+|
+❌ No liability +
+❌ No warranty +
 |===
 
 [[license-attribution]]Requires Attribution::
@@ -142,6 +179,8 @@ version):
 [[license-sharealike]]Share-Alike::
   If you remix, transform, or build upon the material, you must distribute
   your contributions under the same license as the original.
+[[license-documentmodifications]]Document Modifications::
+  Changes made to the licensed material must be documented.
 
 
 == Other Licenses
@@ -189,9 +228,10 @@ Of course choosing a license is a personal decision and any recommendation
 from our side will be subjective. But generally, if you simply don't care
 what people will do with your project, or you want to give them maximum
 freedom (without any liability or warranty from your side), we think
-**CC0-1.0** is a great choice. Or if you want to be more strict and don't
+**CC0-1.0** is a great choice as this will allow _everyone_ to use your
+project for _any_ purpose. If you want to be quite restrictive and don't
 want your project to be used for closed-source products, **CERN-OHL-S-2.0**
-should be reasonable.
+shouldn't be a bad choice.
 
 == License of Libraries
 

--- a/modules/user-manual/pages/licenses.adoc
+++ b/modules/user-manual/pages/licenses.adoc
@@ -1,0 +1,207 @@
+= Licenses
+
+When creating a new project, LibrePCB allows to specify a license for it.
+This chapter gives an overview about the available licenses to help
+you deciding which makes most sense for your project.
+
+First of all, choosing a license is not mandatory. Especially if you don't
+intend to make the project public, it's totally fine to skip the license
+selection. However, for projects made public it's highly recommended to
+specify a license to let other people know what they are allowed or not
+allowed to do with your project. Theoretically you could write your own
+license text, but it's recommended to choose one of the already existing,
+well-known licenses.
+
+[IMPORTANT]
+====
+**Please always read the full, original license text instead of relying on the
+information on this page.** First, this page presents licenses in a very
+simplified form without all their details. Second, this documentation is not
+approved by a lawyer so it may not be correct. We're not responsible for any
+implications caused by incomplete or wrong information on this page.
+====
+
+== Available Licenses
+
+The following licenses are provided by LibrePCB (depending on the installed
+version):
+
+[%autowidth,cols=",,,"]
+|===
+| License | Permissions | Conditions | Limitations
+
+| https://creativecommons.org/publicdomain/zero/1.0/[CC0-1.0]
+|
+✅ Distribution +
+✅ Modification +
+✅ Commercial use +
+|
+|
+❌ No liability +
+❌ No warranty +
+
+| https://creativecommons.org/licenses/by/4.0/[CC-BY-4.0]
+|
+✅ Distribution +
+✅ Modification +
+✅ Commercial use +
+|
+⚠ <<license-attribution>> +
+|
+❌ No liability +
+❌ No warranty +
+
+| https://creativecommons.org/licenses/by-sa/4.0/[CC-BY-SA-4.0]
+|
+✅ Distribution +
+✅ Modification +
+✅ Commercial use +
+|
+⚠ <<license-attribution>> +
+⚠ <<license-sharealike>> +
+|
+❌ No liability +
+❌ No warranty +
+
+| https://creativecommons.org/licenses/by-nc/4.0/[CC-BY-NC-4.0]
+|
+✅ Distribution +
+✅ Modification +
+|
+⚠ <<license-attribution>> +
+|
+❌ No liability +
+❌ No warranty +
+❌ Non-commercial only +
+
+| https://creativecommons.org/licenses/by-nc-sa/4.0/[CC-BY-NC-SA-4.0]
+|
+✅ Distribution +
+✅ Modification +
+|
+⚠ <<license-attribution>> +
+⚠ <<license-sharealike>> +
+|
+❌ No liability +
+❌ No warranty +
+❌ Non-commercial only +
+
+| https://creativecommons.org/licenses/by-nc-nd/4.0/[CC-BY-NC-ND-4.0]
+|
+✅ Distribution +
+✅ Modification +
+|
+⚠ <<license-attribution>> +
+|
+❌ No liability +
+❌ No warranty +
+❌ No derivatives +
+❌ Non-commercial only +
+
+| https://creativecommons.org/licenses/by-nd/4.0/[CC-BY-ND-4.0]
+|
+✅ Distribution +
+✅ Modification +
+✅ Commercial use +
+|
+⚠ <<license-attribution>> +
+|
+❌ No liability +
+❌ No warranty +
+❌ No derivatives +
+
+| https://tapr.org/the-tapr-open-hardware-license/[TAPR-OHL-1.0]
+|
+✅ Distribution +
+✅ Modification +
+✅ Commercial use +
+|
+⚠ <<license-sharealike>> +
+⚠ Document modifications +
+⚠ Notify upstream developers +
+|
+❌ No liability +
+❌ No warranty +
+
+| https://ohwr.org/cern_ohl_p_v2.pdf[CERN-OHL-P-2.0]
+(https://ohwr.org/project/cernohl/wikis/faq[FAQ])
+3+^| _TBD_
+
+| https://ohwr.org/cern_ohl_w_v2.pdf[CERN-OHL-W-2.0]
+(https://ohwr.org/project/cernohl/wikis/faq[FAQ])
+3+^| _TBD_
+
+| https://ohwr.org/cern_ohl_s_v2.pdf[CERN-OHL-S-2.0]
+(https://ohwr.org/project/cernohl/wikis/faq[FAQ])
+3+^| _TBD_
+|===
+
+[[license-attribution]]Requires Attribution::
+  You must give appropriate credit, provide a link to the license,
+  and indicate if changes were made.
+[[license-sharealike]]Share-Alike::
+  If you remix, transform, or build upon the material, you must distribute
+  your contributions under the same license as the original.
+
+
+== Other Licenses
+
+If you like to use a license not available in LibrePCB, or if you're not sure
+yet and want to decide later, just skip the license selection when creating
+the project. Then add it manually afterwards as follows:
+
+1. Close the project in LibrePCB.
+2. In the root directory of the project, add a file named `LICENSE.txt`
+   containing the license terms.
+3. Open `README.md` in a text editor and replace this line: +
++
+[source,markdown]
+----
+No license set.
+----
++
+by this one:
++
+[source,markdown]
+----
+See [LICENSE.txt](LICENSE.txt).
+----
+
+Or if you want to switch to a different license after you created a new
+project, just replace the file `LICENSE.txt` manually. LibrePCB itself does
+not provide a tool to change the license of an existing project.
+
+== Additional Actions
+
+Note that some licenses may require to perform additional actions to correctly
+apply those licenses to a project. This applies mainly to the OHL licenses,
+but to be sure please check the license texts.
+
+[NOTE]
+====
+Please help us documenting the additional actions
+https://github.com/LibrePCB/librepcb-doc[on GitHub]!
+====
+
+== Recommendation
+
+Of course choosing a license is a personal decision and any recommendation
+from our side will be subjective. But generally, if you simply don't care
+what people will do with your project, or you want to give them maximum
+freedom (without any liability or warranty from your side), we think
+**CC0-1.0** is a great choice. Or if you want to be more strict and don't
+want your project to be used for closed-source products, **CERN-OHL-S-2.0**
+should be reasonable.
+
+== License of Libraries
+
+Not only projects, but also libraries can be released under a certain
+license. However, we think public libraries should be released exclusively
+under the **CC0-1.0** license. Any other license would make it too
+complicated for other people to create projects using these libraries,
+fulfilling all license terms of any used library.
+
+Thus when creating a new library, CC0-1.0 is the only available option and
+all official libraries are published under this license so you can do with
+these libraries whatever you want, whether for commercial or non-commercial
+use.

--- a/modules/user-manual/pages/licenses.adoc
+++ b/modules/user-manual/pages/licenses.adoc
@@ -48,7 +48,8 @@ https://choosealicense.com/licenses/cc-by-4.0/[Summary]
 ✅ Modification +
 ✅ Commercial use +
 |
-⚠ <<license-attribution>> +
+⚠ <<license-notice>> +
+⚠ <<license-statechanges>> +
 |
 ❌ No liability +
 ❌ No warranty +
@@ -60,8 +61,9 @@ https://choosealicense.com/licenses/cc-by-sa-4.0/[Summary]
 ✅ Modification +
 ✅ Commercial use +
 |
-⚠ <<license-attribution>> +
-⚠ <<license-sharealike>> +
+⚠ <<license-notice>> +
+⚠ <<license-statechanges>> +
+⚠ <<license-samelicense>> +
 |
 ❌ No liability +
 ❌ No warranty +
@@ -71,7 +73,8 @@ https://choosealicense.com/licenses/cc-by-sa-4.0/[Summary]
 ✅ Distribution +
 ✅ Modification +
 |
-⚠ <<license-attribution>> +
+⚠ <<license-notice>> +
+⚠ <<license-statechanges>> +
 |
 ❌ No liability +
 ❌ No warranty +
@@ -82,8 +85,9 @@ https://choosealicense.com/licenses/cc-by-sa-4.0/[Summary]
 ✅ Distribution +
 ✅ Modification +
 |
-⚠ <<license-attribution>> +
-⚠ <<license-sharealike>> +
+⚠ <<license-notice>> +
+⚠ <<license-statechanges>> +
+⚠ <<license-samelicense>> +
 |
 ❌ No liability +
 ❌ No warranty +
@@ -94,7 +98,8 @@ https://choosealicense.com/licenses/cc-by-sa-4.0/[Summary]
 ✅ Distribution +
 ✅ Modification +
 |
-⚠ <<license-attribution>> +
+⚠ <<license-notice>> +
+⚠ <<license-statechanges>> +
 |
 ❌ No liability +
 ❌ No warranty +
@@ -107,7 +112,8 @@ https://choosealicense.com/licenses/cc-by-sa-4.0/[Summary]
 ✅ Modification +
 ✅ Commercial use +
 |
-⚠ <<license-attribution>> +
+⚠ <<license-notice>> +
+⚠ <<license-statechanges>> +
 |
 ❌ No liability +
 ❌ No warranty +
@@ -119,8 +125,9 @@ https://choosealicense.com/licenses/cc-by-sa-4.0/[Summary]
 ✅ Modification +
 ✅ Commercial use +
 |
-⚠ <<license-sharealike>> +
-⚠ <<license-documentmodifications>> +
+⚠ <<license-notice>> +
+⚠ <<license-statechanges>> +
+⚠ <<license-samelicense>> +
 ⚠ Notify upstream developers +
 |
 ❌ No liability +
@@ -134,8 +141,8 @@ https://ohwr.org/project/cernohl/wikis/faq[FAQ]
 ✅ Modification +
 ✅ Commercial use +
 |
-⚠ <<license-documentmodifications>> +
-⚠ License and copyright notice +
+⚠ <<license-notice>> +
+⚠ <<license-statechanges>> +
 |
 ❌ No liability +
 ❌ No warranty +
@@ -148,9 +155,9 @@ https://ohwr.org/project/cernohl/wikis/faq[FAQ]
 ✅ Modification +
 ✅ Commercial use +
 |
-⚠ <<license-sharealike>> (relaxed) +
-⚠ <<license-documentmodifications>> +
-⚠ License and copyright notice +
+⚠ <<license-notice>> +
+⚠ <<license-statechanges>> +
+⚠ <<license-samelicense>> (relaxed) +
 ⚠ Disclose source +
 |
 ❌ No liability +
@@ -164,24 +171,23 @@ https://ohwr.org/project/cernohl/wikis/faq[FAQ]
 ✅ Modification +
 ✅ Commercial use +
 |
-⚠ <<license-sharealike>> (strong) +
-⚠ <<license-documentmodifications>> +
-⚠ License and copyright notice +
+⚠ <<license-notice>> +
+⚠ <<license-statechanges>> +
+⚠ <<license-samelicense>> (strong) +
 ⚠ Disclose source +
 |
 ❌ No liability +
 ❌ No warranty +
 |===
 
-[[license-attribution]]Requires Attribution::
-  You must give appropriate credit, provide a link to the license,
-  and indicate if changes were made.
-[[license-sharealike]]Share-Alike::
+[[license-notice]]License and Copyright Notice::
+  A copy of the license and copyright notice must be included with the
+  licensed material.
+[[license-statechanges]]State Changes::
+  Modifications made to the licensed material must be documented.
+[[license-samelicense]]Same License::
   If you remix, transform, or build upon the material, you must distribute
   your contributions under the same license as the original.
-[[license-documentmodifications]]Document Modifications::
-  Changes made to the licensed material must be documented.
-
 
 == Other Licenses
 


### PR DESCRIPTION
For https://github.com/LibrePCB/LibrePCB/pull/1247, to add a hyperlink to the application pointing to a documentation site explaining the available license options.

Preview: https://docs.librepcb.org/_branches/document-licenses/librepcb/user-manual/licenses/

I'm really not a license expert so I hope these entries are correct so far, ~~and I didn't fill out the CERN-OHL rows yet because I'm not sure~~ *(EDIT: filled out with the help of choosealicense.com)*. Would be nice to get support from someone with more knowledge about these licenses :wink: However, I'll merge anyway soon to get a working hyperlink for the application - content can still be improved later.

Also would be nice to get feedback about some recommendations I've made on this new page:
- Using CC0-1.0 for projects when you want to give other people freedom
- Using CERN-OHL-S-2.0 if you want to avoid closed-source products based on your project (does this make sense?)
- For libraries, only CC0-1.0 should be used (from my point of view)

@dbrgn @rnestler maybe you know more about licensing?